### PR TITLE
Add browser tracking to login

### DIFF
--- a/internal/controllers/user.controller.go
+++ b/internal/controllers/user.controller.go
@@ -90,12 +90,20 @@ func (c *UserController) Login(ctx *gin.Context) {
 		middlewares.HandleError(ctx, err, response.UnprocessableEntity)
 		return
 	}
+	ua := auth.GetUserAgentDetails(ctx.Request.Header.Get("User-Agent"))
+	device := ""
+	browser := ""
+	if ua != nil {
+		device = ua.Platform()
+		browser, _ = ua.Browser()
+	}
 	userSession := vo.UserSession{
- 		IpAddress: ctx.ClientIP(),
+		IpAddress: ctx.ClientIP(),
 		Location:  auth.GetLocationFromIP(ctx.ClientIP()),
-		Device:    auth.GetUserAgentDetails(ctx.Request.Header.Get("User-Agent")).Platform(),
- 		UserAgent: ctx.Request.Header.Get("User-Agent"),
- 	}
+		Device:    device,
+		Browser:   browser,
+		UserAgent: ctx.Request.Header.Get("User-Agent"),
+	}
 	token, err := c.userService.Login(params.Email, params.Password, userSession)
 	if err != nil {
 		middlewares.HandleError(ctx, err, response.BadRequest)

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -10,13 +10,13 @@ import (
 )
 
 type User struct {
-	ID             uuid.UUID `json:"id" gorm:"type:uuid;primary_key;default:gen_random_uuid()"`
-	Username       string    `json:"username" gorm:"uniqueIndex;not null"`
-	Email          string    `json:"email" gorm:"uniqueIndex;not null"`
-	Password       string    `json:"-" gorm:"not null"` // "-" means this field won't be included in JSON
-	Role           enum.Role `json:"role" gorm:"type:varchar(20);not null;default:'user'"`
-	UserLoginTime  time.Time `json:"-" gorm:"default:null"`
-	UserLoginIP    string    `json:"-" gorm:"default:null"`
+	ID            uuid.UUID `json:"id" gorm:"type:uuid;primary_key;default:gen_random_uuid()"`
+	Username      string    `json:"username" gorm:"uniqueIndex;not null"`
+	Email         string    `json:"email" gorm:"uniqueIndex;not null"`
+	Password      string    `json:"-" gorm:"not null"` // "-" means this field won't be included in JSON
+	Role          enum.Role `json:"role" gorm:"type:varchar(20);not null;default:'user'"`
+	UserLoginTime time.Time `json:"-" gorm:"default:null"`
+	UserLoginIP   string    `json:"-" gorm:"default:null"`
 
 	UserLogoutTime time.Time `json:"-" gorm:"default:null"`
 	UserSalt       string    `json:"-" gorm:"default:null"` // user_salt is the salt that will be used to hash the password
@@ -33,6 +33,7 @@ type UserSession struct {
 	IpAddress string    `json:"ip_address" gorm:"default:null"`
 	Location  string    `json:"location" gorm:"default:null"`
 	Device    string    `json:"device" gorm:"default:null"`
+	Browser   string    `json:"browser" gorm:"default:null"`
 	UserAgent string    `json:"user_agent" gorm:"default:null"`
 	UserId    uuid.UUID `json:"user_id" gorm:"type:uuid;not null;constraint:OnDelete:CASCADE"`
 	User      *User     `json:"user" gorm:"foreignKey:UserId"`
@@ -71,8 +72,8 @@ type Seller struct {
 	BlockedByUser *User      `json:"blocked_by_user" gorm:"foreignKey:BlockedBy"`
 	BlockedReason *string    `json:"blocked_reason" gorm:"default:null"`
 	User          *User      `json:"user" gorm:"foreignKey:UserId"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	CreatedAt     time.Time  `json:"created_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
 }
 
 // TableName specifies the table name for the User model

--- a/internal/repositories/user/user_session.repo.go
+++ b/internal/repositories/user/user_session.repo.go
@@ -8,7 +8,7 @@ import (
 )
 
 type IUserSessionRepository interface {
-	CreateUserSession(userId uuid.UUID, ipAddress string, location string, device string, userAgent string) error
+	CreateUserSession(userId uuid.UUID, ipAddress string, location string, device string, browser string, userAgent string) error
 	GetUserSessionByUserId(userId uuid.UUID) (*model.UserSession, error)
 	DeleteUserSession(userId uuid.UUID) error
 }
@@ -21,12 +21,13 @@ func NewUserSessionRepository(db *gorm.DB) IUserSessionRepository {
 	return &userSessionRepository{db: db}
 }
 
-func (u *userSessionRepository) CreateUserSession(userId uuid.UUID, ipAddress string, location string, device string, userAgent string) error {
+func (u *userSessionRepository) CreateUserSession(userId uuid.UUID, ipAddress string, location string, device string, browser string, userAgent string) error {
 	return u.db.Create(&model.UserSession{
 		UserId:    userId,
 		IpAddress: ipAddress,
 		Location:  location,
 		Device:    device,
+		Browser:   browser,
 		UserAgent: userAgent,
 	}).Error
 }

--- a/internal/services/user/user.service.go
+++ b/internal/services/user/user.service.go
@@ -82,7 +82,7 @@ func (s *userService) Login(email string, password string, user_session vo.UserS
 	if err != nil {
 		return "", err
 	}
-	err = s.userSessionRepo.CreateUserSession(user.ID, user_session.IpAddress, user_session.Location, user_session.Device, user_session.UserAgent)
+	err = s.userSessionRepo.CreateUserSession(user.ID, user_session.IpAddress, user_session.Location, user_session.Device, user_session.Browser, user_session.UserAgent)
 	if err != nil {
 		return "", err
 	}

--- a/internal/utils/auth/get_session.go
+++ b/internal/utils/auth/get_session.go
@@ -15,10 +15,10 @@ func GetLocationFromIP(ip string) string {
 	if net.ParseIP(ip) == nil {
 		return ""
 	}
-    
-    url := fmt.Sprintf("https://ip-api.com/json/%s", ip)
-    client := &http.Client{Timeout: 10 * time.Second}
-    resp, err := client.Get(url)
+
+	url := fmt.Sprintf("https://ip-api.com/json/%s", ip)
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
 	if err != nil {
 		return ""
 	}

--- a/internal/vo/user.vo.go
+++ b/internal/vo/user.vo.go
@@ -1,15 +1,14 @@
 package vo
 
-
 type UserLoginRequest struct {
-	Email   string `json:"email" binding:"required,email"`
+	Email    string `json:"email" binding:"required,email"`
 	Password string `json:"password" binding:"required"`
 }
 
 type UserRegisterRequest struct {
-	Username string `json:"username" binding:"required,min=1"`
-	Email   string `json:"email" binding:"required,email"`
-	Password string `json:"password" binding:"required"`
+	Username string  `json:"username" binding:"required,min=1"`
+	Email    string  `json:"email" binding:"required,email"`
+	Password string  `json:"password" binding:"required"`
 	Purpose  *string `json:"purpose"` // TEST_USER, TRADER, ADMIN, etc.
 }
 
@@ -50,5 +49,6 @@ type UserSession struct {
 	IpAddress string `json:"ip_address"`
 	Location  string `json:"location"`
 	Device    string `json:"device"`
+	Browser   string `json:"browser"`
 	UserAgent string `json:"user_agent"`
 }


### PR DESCRIPTION
## Summary
- capture browser info when users log in
- record the browser in user sessions
- remove standalone browser parser and use `GetUserAgentDetails`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_6843de05da24832ab73d056d389563fc