### PR TITLE
Add multi queue support for RabbitMQ

### DIFF
--- a/cmd/notification_worker/main.go
+++ b/cmd/notification_worker/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"log"
+
+	"ecommerce/global"
+	"ecommerce/internal/initialize"
+	repoNotif "ecommerce/internal/repositories/notification"
+	repoUser "ecommerce/internal/repositories/user"
+	serviceNotif "ecommerce/internal/services/notification"
+	"ecommerce/internal/worker"
+)
+
+func main() {
+	initialize.InitEnv()
+	initialize.LoadConfig()
+	initialize.InitLogger()
+	initialize.InitDB()
+	initialize.InitRabbitMQ()
+
+	notifRepo := repoNotif.NewNotificationRepository(global.DB)
+	adminRepo := repoUser.NewAdminRepository(global.DB)
+	notifService := serviceNotif.NewNotificationService(notifRepo, adminRepo)
+
+	queueName := global.Config.RabbitMQ.Queues["notification"]
+	w := worker.NewNotificationWorker(global.RabbitMQ, notifService, queueName)
+	if err := w.Start(); err != nil {
+		log.Fatalf("failed to start notification worker: %v", err)
+	}
+
+	select {}
+}

--- a/configs/local.yaml
+++ b/configs/local.yaml
@@ -49,3 +49,5 @@ rabbitmq:
   port: 5672
   username: guest
   password: guest
+  queues:
+    notification: seller_approval_queue

--- a/internal/initialize/rabbitmq.go
+++ b/internal/initialize/rabbitmq.go
@@ -16,10 +16,17 @@ func InitRabbitMQ() {
 		global.Config.RabbitMQ.Port,
 	)
 	fmt.Println(rabbitmqUrl)
-	queueService, err := queue.NewQueueService(rabbitmqUrl, global.Config.RabbitMQ.QueueName,"seller_approval_exchange")
+	queueService, err := queue.NewQueueService(rabbitmqUrl)
 	if err != nil {
 		log.Fatalf("Failed to connect to RabbitMQ: %v", err)
 	}
 
 	global.RabbitMQ = queueService
+
+	// ensure default notification queue and exchange exist
+	if q, ok := global.Config.RabbitMQ.Queues["notification"]; ok {
+		if err := queueService.CreateQueueAndBind("seller_approval_exchange", q, "seller.approved"); err != nil {
+			log.Fatalf("Failed to declare queue: %v", err)
+		}
+	}
 }

--- a/internal/model/notification.go
+++ b/internal/model/notification.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Notification struct {
+	ID        uuid.UUID `json:"id" gorm:"type:uuid;primary_key;default:gen_random_uuid()"`
+	UserID    uuid.UUID `json:"user_id" gorm:"type:uuid;index;not null"`
+	Message   string    `json:"message" gorm:"type:text;not null"`
+	Read      bool      `json:"read" gorm:"default:false"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+func (Notification) TableName() string {
+	return "notifications"
+}

--- a/internal/repositories/notification/notification.repo.go
+++ b/internal/repositories/notification/notification.repo.go
@@ -1,0 +1,23 @@
+package repo
+
+import (
+	"ecommerce/internal/model"
+
+	"gorm.io/gorm"
+)
+
+type INotificationRepository interface {
+	Create(notification *model.Notification) error
+}
+
+type notificationRepository struct {
+	db *gorm.DB
+}
+
+func (r *notificationRepository) Create(notification *model.Notification) error {
+	return r.db.Create(notification).Error
+}
+
+func NewNotificationRepository(db *gorm.DB) INotificationRepository {
+	return &notificationRepository{db: db}
+}

--- a/internal/repositories/user/admin.repo.go
+++ b/internal/repositories/user/admin.repo.go
@@ -14,6 +14,7 @@ type IAdminRepository interface {
 	ApproveSellerRequest(userId uuid.UUID, sellerId string, approved bool) error
 	BlockSeller(userId uuid.UUID, sellerId string, reason string) error
 	CheckAdmin(userId uuid.UUID) (bool, error)
+	GetAllAdmins() ([]*model.User, error)
 }
 
 type adminRepository struct {
@@ -53,4 +54,13 @@ func (a *adminRepository) CheckAdmin(userId uuid.UUID) (bool, error) {
 		return false, err
 	}
 	return user.Role == enum.UserRole.Admin, nil
+}
+
+func (a *adminRepository) GetAllAdmins() ([]*model.User, error) {
+	var users []*model.User
+	err := a.db.Where("role = ?", enum.UserRole.Admin).Find(&users).Error
+	if err != nil {
+		return nil, err
+	}
+	return users, nil
 }

--- a/internal/services/notification/notification.service.go
+++ b/internal/services/notification/notification.service.go
@@ -1,0 +1,40 @@
+package notification
+
+import (
+	"ecommerce/internal/model"
+	notifRepo "ecommerce/internal/repositories/notification"
+	adminRepo "ecommerce/internal/repositories/user"
+)
+
+type INotificationService interface {
+	NotifyAdmins(message string) error
+}
+
+type notificationService struct {
+	notificationRepo notifRepo.INotificationRepository
+	adminRepo        adminRepo.IAdminRepository
+}
+
+func NewNotificationService(nRepo notifRepo.INotificationRepository, aRepo adminRepo.IAdminRepository) INotificationService {
+	return &notificationService{
+		notificationRepo: nRepo,
+		adminRepo:        aRepo,
+	}
+}
+
+func (s *notificationService) NotifyAdmins(message string) error {
+	admins, err := s.adminRepo.GetAllAdmins()
+	if err != nil {
+		return err
+	}
+	for _, admin := range admins {
+		n := &model.Notification{
+			UserID:  admin.ID,
+			Message: message,
+		}
+		if err := s.notificationRepo.Create(n); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/services/user/admin.service.go
+++ b/internal/services/user/admin.service.go
@@ -49,6 +49,14 @@ func (s *adminService) ApproveSellerRequest(userId string, sellerId, sellerEmail
 				global.Logger.Errorf("Failed to send approval email to %s: %v", email, err)
 			}
 		}(sellerEmail)
+
+		// publish notification message to RabbitMQ
+		go func() {
+			msg := map[string]string{"message": "A seller has been approved"}
+			if err := global.RabbitMQ.PublishMessage(msg, "seller_approval_exchange", "seller.approved"); err != nil {
+				global.Logger.Errorf("Failed to publish notification: %v", err)
+			}
+		}()
 	}
 	return nil
 }

--- a/internal/worker/notification.worker.go
+++ b/internal/worker/notification.worker.go
@@ -1,0 +1,45 @@
+package worker
+
+import (
+	"encoding/json"
+	"log"
+
+	"ecommerce/internal/services/notification"
+	"ecommerce/internal/services/queue"
+)
+
+type NotificationPayload struct {
+	Message string `json:"message"`
+}
+
+type NotificationWorker struct {
+	queue     queue.IQueueService
+	service   notification.INotificationService
+	queueName string
+}
+
+func NewNotificationWorker(q queue.IQueueService, s notification.INotificationService, queueName string) *NotificationWorker {
+	return &NotificationWorker{queue: q, service: s, queueName: queueName}
+}
+
+func (w *NotificationWorker) Start() error {
+	if err := w.queue.CreateQueueAndBind("seller_approval_exchange", w.queueName, "seller.approved"); err != nil {
+		return err
+	}
+	msgs, err := w.queue.ConsumeMessages(w.queueName)
+	if err != nil {
+		return err
+	}
+	go func() {
+		for m := range msgs {
+			var payload NotificationPayload
+			if err := json.Unmarshal(m.Body, &payload); err != nil {
+				continue
+			}
+			if err := w.service.NotifyAdmins(payload.Message); err != nil {
+				log.Printf("failed to create notification: %v", err)
+			}
+		}
+	}()
+	return nil
+}

--- a/pkg/setting/section.go
+++ b/pkg/setting/section.go
@@ -73,9 +73,9 @@ type Logger struct {
 }
 
 type RabbitMQ struct {
-	Host      string `mapstructure:"host"`
-	Port      int    `mapstructure:"port"`
-	Username  string `mapstructure:"username"`
-	Password  string `mapstructure:"password"`
-	QueueName string `mapstructure:"queue_name"`
+	Host     string            `mapstructure:"host"`
+	Port     int               `mapstructure:"port"`
+	Username string            `mapstructure:"username"`
+	Password string            `mapstructure:"password"`
+	Queues   map[string]string `mapstructure:"queues"`
 }


### PR DESCRIPTION
## Summary
- allow multiple RabbitMQ queues in config
- create RabbitMQ service without queue name
- declare exchange and queue in initialization
- update notification worker to use queue from config

## Testing
- `go vet ./...`
- `go test ./...` *(fails: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_68450c40aaac832a93c19682911abceb